### PR TITLE
Fix CPF implicit cast validation

### DIFF
--- a/cpf.c
+++ b/cpf.c
@@ -100,3 +100,15 @@ cpfin(PG_FUNCTION_ARGS)
 
 	PG_RETURN_INT64(value);
 }
+
+PG_FUNCTION_INFO_V1(cpfbigint);
+
+Datum
+cpfbigint(PG_FUNCTION_ARGS)
+{
+	int64		value = PG_GETARG_INT64(0);
+
+	validate_cpf(value);
+
+	PG_RETURN_INT64(value);
+}

--- a/expected/cpf.out
+++ b/expected/cpf.out
@@ -13,6 +13,16 @@ Indexes:
 
 -- Valid and generated CPFs using: https://theonegenerator.com/pt/geradores/documentos/gerador-de-cpf/
 INSERT INTO pessoa VALUES (cpf '40100276300'), (16426332836);
+-- Should fail the implicit cast because it is an invalid CPF
+INSERT INTO pessoa VALUES (11111111111);
+ERROR:  invalid CPF
+DETAIL:  All CPF digits should not be equal.
+INSERT INTO pessoa VALUES (16426332830);
+ERROR:  invalid CPF
+DETAIL:  Invalid check digit for the CPF.
+INSERT INTO pessoa VALUES (-1::bigint);
+ERROR:  invalid CPF
+DETAIL:  CPF should not be less than 100 and greater than 99999999999.
 SELECT * FROM pessoa ORDER BY cpf;
       cpf       
 ----------------

--- a/pg_toolkit_brazil--0.1.sql
+++ b/pg_toolkit_brazil--0.1.sql
@@ -41,12 +41,21 @@ CREATE TYPE cpf (
     LIKE    = int8
 );
 
+--
+-- Type casting functions.
+--
+
+CREATE FUNCTION cpfbigint(bigint)
+RETURNS cpf
+AS 'MODULE_PATHNAME'
+LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 
 --
 --  Implicit and assignment type casts.
 --
 
-CREATE CAST (bigint AS cpf) WITHOUT FUNCTION AS IMPLICIT;
+CREATE CAST (bigint AS cpf) WITH FUNCTION cpfbigint(bigint) AS IMPLICIT;
 
 --
 -- Operator Functions.

--- a/sql/cpf.sql
+++ b/sql/cpf.sql
@@ -4,9 +4,17 @@ CREATE TABLE pessoa(
     cpf cpf NOT NULL,
     PRIMARY KEY (cpf)
 );
+
 \d pessoa
+
 -- Valid and generated CPFs using: https://theonegenerator.com/pt/geradores/documentos/gerador-de-cpf/
 INSERT INTO pessoa VALUES (cpf '40100276300'), (16426332836);
+
+-- Should fail the implicit cast because it is an invalid CPF
+INSERT INTO pessoa VALUES (11111111111);
+INSERT INTO pessoa VALUES (16426332830);
+INSERT INTO pessoa VALUES (-1::bigint);
+
 SELECT * FROM pessoa ORDER BY cpf;
 
 -- invalid CPFs


### PR DESCRIPTION
The first implicit cast implementation was not executing the proper CPF validation.

Fixed it by executing a function with the proper validation when casting from BIGINT to CPF datatype.

Fix #3

Signed-off-by: Fabrízio de Royes Mello <fabriziomello@gmail.com>